### PR TITLE
Hdl 285 paypal sdk header: Fixing Case Sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.0.1
+* Fix Case Sensitivity of Content Type for deserialization process
+
 ## 1.0.0
 - First Release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2019 PayPal, Inc.
+Copyright (c) 2009-2021 PayPal, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/PayPalHttp-Dotnet.Tests/HttpClientTest.cs
+++ b/PayPalHttp-Dotnet.Tests/HttpClientTest.cs
@@ -207,6 +207,29 @@ namespace PayPalHttp.Tests
         }
 
         [Fact]
+        public async void Execute_withData_SerializesDataAccordingToContentTypeCaseInsensitive()
+        {
+            server.Given(
+                Request.Create().WithPath("/")
+                .UsingPost()
+                .WithBody("{\"name\":\"paypal\"}")
+            ).RespondWith(
+                Response.Create().WithStatusCode(200)
+            );
+            var request = new HttpRequest("/", HttpMethod.Post, typeof(void));
+            request.ContentType = "application/JSON";
+            request.Body = new TestData
+            {
+                Name = "paypal"
+            };
+
+            var client = Client();
+
+            var response = await client.Execute(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
         public async void Execute_withReturnData_DeserializesAccordingToContentType()
         {
             server.Given(
@@ -217,6 +240,25 @@ namespace PayPalHttp.Tests
                 .WithBody("{\"name\":\"\"}")
                 .WithBody("{\"name\":\"paypal\"}")
                 .WithHeader("Content-Type", "application/json; charset=utf-8")
+            );
+            var request = new HttpRequest("/", HttpMethod.Get, typeof(TestData));
+
+            var response = await Client().Execute(request);
+
+            Assert.Equal("paypal", response.Result<TestData>().Name);
+        }
+
+        [Fact]
+        public async void Execute_withReturnData_DeserializesAccordingToContentTypeCaseInsensitive()
+        {
+            server.Given(
+                Request.Create().WithPath("/")
+                .UsingGet()
+            ).RespondWith(
+                Response.Create().WithStatusCode(200)
+                .WithBody("{\"name\":\"\"}")
+                .WithBody("{\"name\":\"paypal\"}")
+                .WithHeader("Content-Type", "application/JSON; charset=utf-8")
             );
             var request = new HttpRequest("/", HttpMethod.Get, typeof(TestData));
 

--- a/PayPalHttp-Dotnet/Encoder.cs
+++ b/PayPalHttp-Dotnet/Encoder.cs
@@ -38,6 +38,9 @@ namespace PayPalHttp
             {
                 throw new IOException("HttpRequest did not have content-type header set");
             }
+
+            request.ContentType = request.ContentType.ToLower();
+            
             ISerializer serializer = GetSerializer(request.ContentType);
             if (serializer == null)
             {
@@ -62,6 +65,7 @@ namespace PayPalHttp
                 throw new IOException("HTTP response did not have content-type header set");
             }
             var contentType = content.Headers.ContentType.ToString();
+            contentType = contentType.ToLower();
             ISerializer serializer = GetSerializer(contentType);
             if (serializer == null)
             {

--- a/PayPalHttp-Dotnet/PayPalHttp-Dotnet.csproj
+++ b/PayPalHttp-Dotnet/PayPalHttp-Dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Title>PayPalHttp</Title>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Copyright>Copyright PayPal, Inc. 2019</Copyright>
     <Description>PayPalHttp is a generic http client designed to be used with code-generated projects.</Description>
     <Authors>PayPal</Authors>


### PR DESCRIPTION
Internal Change for Ticket 285: 

Author: hlahlou

Changes made in Encoder and HttpClient to force the value for Content-Type to lowercase.

Added Unit Tests to ensure that deserialization and execution of HTTP request were case insensitive and could handle Content-Types of different casing (ex: application/json vs application/JSON)

Also updated the license, change log, and version to reflect changes made and to update copyright.


Results of Unit Tests:
<img width="1792" alt="Screen Shot 2021-08-25 at 1 08 45 PM" src="https://user-images.githubusercontent.com/30755392/130838672-db957079-37a8-4ff1-83d6-b63d468ffb14.png">

Integration Test Results with Checkout SDK:
<img width="1792" alt="Screen Shot 2021-09-01 at 3 44 58 PM" src="https://user-images.githubusercontent.com/30755392/131735930-3a3f3a6e-25a0-4570-a01d-5931443aaa04.png">
